### PR TITLE
Contribute a GitHub Actions workflow for building the screensaver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           name: WebSaver
           path: /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug
       - name: Pack the build directory for release
-        run: zip WebSaver.zip /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug/
+        run: zip -j WebSaver.zip /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug/
       # Note https://github.com/rickstaa/action-create-tag doesn't work on macOS
       - name: Tag the repository
         id: tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,8 @@ jobs:
           path: /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug
       - name: Pack the build directory for release
         run: |
-          cd /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/
-          zip -r ${{ github.workspace }}/WebSaver.zip Debug/
+          cd /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug
+          zip -r ${{ github.workspace }}/WebSaver.zip .
       # Note https://github.com/rickstaa/action-create-tag doesn't work on macOS
       - name: Tag the repository
         id: tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Tag the repository
         run: |
           # See https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names
-          TAG=$(date -Iseconds | sed 's/[T:\+]/-/g')
+          TAG=v$(date -Iseconds | sed 's/[T:\+]/-/g')
           echo "$TAG"
-          echo "tag=v$TAG" >> $GITHUB_OUTPUT
-          git tag -a v$TAG -m "Published version $TAG" ${GITHUB_SHA}
-          git push origin v$TAG
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          git tag -a $TAG -m "Published version $TAG" ${GITHUB_SHA}
+          git push origin $TAG
       - name: Cut a new release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,6 @@ jobs:
     steps:
       - name: Check out the source code for XCode
         uses: actions/checkout@v3
-      - name: Install `tree` using Homebrew
-        run: brew install tree
-      - name: Tree the repository directory prior to the build
-        run: tree -a
       - name: Build the XCode project
         uses: sersoft-gmbh/xcodebuild-action@v2
         with:
@@ -18,4 +14,4 @@ jobs:
           destination: platform=macOS
           action: build
       - name: Tree the repository directory after the build
-        run: tree -a
+        run: find /Users/runner/Library/Developer/Xcode/DerivedData/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,22 @@ jobs:
           path: /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug
       - name: Pack the build directory for release
         run: zip WebSaver.zip /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug/
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.7
+        with:
+          versionSpec: '5.x'
+      - name: Determine Version
+        uses: gittools/actions/gitversion/execute@v0.9.7
+      - name: Display SemVer
+        run: |
+          echo "SemVer: $GITVERSION_SEMVER" && echo "$version" && echo "$major.$minor.$patch"
+      - name: Create git tag
+        run: |
+          git tag $GITVERSION_SEMVER
+      - name: Push git tag
+        run: git push origin $GITVERSION_SEMVER 
       - name: Cut a new release
         uses: softprops/action-gh-release@v1
         with:
           files: WebSaver.zip
+          tag_name: $GITVERSION_SEMVER 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,12 +22,13 @@ jobs:
           path: /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug
       - name: Pack the build directory for release
         run: zip WebSaver.zip /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug/
+      # Note https://github.com/rickstaa/action-create-tag doesn't work on macOS
       - name: Tag the repository
         run: |
           # See https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names
           TAG=$(date -Iseconds | sed 's/[T:\+]/-/g')
           echo "$TAG"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "tag=v$TAG" >> $GITHUB_OUTPUT
           git tag -a v$TAG -m "Published version $TAG" ${GITHUB_SHA}
           git push origin v$TAG
       - name: Cut a new release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
         with:
           project: WebSaver.xcodeproj
           scheme: WebSaver
-          destination: platform=macOS
           action: build
       - name: Upload the build directory as an artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,22 +22,13 @@ jobs:
           path: /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug
       - name: Pack the build directory for release
         run: zip WebSaver.zip /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug/
-      - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.7
-        with:
-          versionSpec: '5.x'
-      - name: Determine Version
-        uses: gittools/actions/gitversion/execute@v0.9.7
-      - name: Display SemVer
+      - name: Tag the repository
         run: |
-          echo "SemVer: $GITVERSION_SEMVER" && echo "$version" && echo "$major.$minor.$patch"
-      - name: Create git tag
-        run: |
-          git tag $GITVERSION_SEMVER
-      - name: Push git tag
-        run: git push origin $GITVERSION_SEMVER 
+          TAG=$(date -Iseconds)
+          git tag -a v$TAG -m "Published version $TAG" ${GITHUB_SHA}
+          git push origin v$TAG
       - name: Cut a new release
         uses: softprops/action-gh-release@v1
         with:
           files: WebSaver.zip
-          tag_name: $GITVERSION_SEMVER 
+          tag_name: $TAG

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         run: zip WebSaver.zip /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug/
       # Note https://github.com/rickstaa/action-create-tag doesn't work on macOS
       - name: Tag the repository
+        id: tag
         run: |
           # See https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names
           TAG=v$(date -Iseconds | sed 's/[T:\+]/-/g')
@@ -35,4 +36,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: WebSaver.zip
-          tag_name: ${{ steps.vars.outputs.tag }}
+          tag_name: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,5 +13,8 @@ jobs:
           scheme: WebSaver
           destination: platform=macOS
           action: build
-      - name: Tree the repository directory after the build
-        run: find /Users/runner/Library/Developer/Xcode/DerivedData/
+      - name: Upload the build directory as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: WebSaver
+          path: /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,8 @@ jobs:
         run: zip WebSaver.zip /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug/
       - name: Tag the repository
         run: |
-          TAG=$(date -Iseconds)
+          # See https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names
+          TAG=$(date -Iseconds | sed 's/[T:\+]/-/g')
           git tag -a v$TAG -m "Published version $TAG" ${GITHUB_SHA}
           git push origin v$TAG
       - name: Cut a new release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - name: Check out the source code for XCode
         uses: actions/checkout@v3
+      - name: Install `tree` using Homebrew
+        run: brew install tree
       - name: Tree the repository directory prior to the build
         run: tree -a
       - name: Build the XCode project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,12 @@ jobs:
         run: |
           # See https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names
           TAG=$(date -Iseconds | sed 's/[T:\+]/-/g')
+          echo "$TAG"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
           git tag -a v$TAG -m "Published version $TAG" ${GITHUB_SHA}
           git push origin v$TAG
       - name: Cut a new release
         uses: softprops/action-gh-release@v1
         with:
           files: WebSaver.zip
-          tag_name: $TAG
+          tag_name: ${{ steps.vars.outputs.tag }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           name: WebSaver
           path: /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug
       - name: Pack the build directory for release
-        run: zip -j WebSaver.zip /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug/
+        run: zip -jr WebSaver.zip /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug/
       # Note https://github.com/rickstaa/action-create-tag doesn't work on macOS
       - name: Tag the repository
         id: tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,19 @@
+name: build
+on: [push]
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Check out the source code for XCode
+        uses: actions/checkout@v3
+      - name: Tree the repository directory prior to the build
+        run: tree -a
+      - name: Build the XCode project
+        uses: sersoft-gmbh/xcodebuild-action@v2
+        with:
+          project: WebSaver.xcodeproj
+          scheme: WebSaver
+          destination: platform=macOS
+          action: build
+      - name: Tree the repository directory after the build
+        run: tree -a

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,9 @@ jobs:
           name: WebSaver
           path: /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug
       - name: Pack the build directory for release
-        run: zip -jr WebSaver.zip /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug/
+        run: |
+          cd /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/
+          zip -r ${{ github.workspace }}/WebSaver.zip Debug/
       # Note https://github.com/rickstaa/action-create-tag doesn't work on macOS
       - name: Tag the repository
         id: tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ on: [push]
 jobs:
   build:
     runs-on: macos-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out the source code for XCode
         uses: actions/checkout@v3
@@ -18,3 +20,9 @@ jobs:
         with:
           name: WebSaver
           path: /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug
+      - name: Pack the build directory for release
+        run: zip WebSaver.zip /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug/
+      - name: Cut a new release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: WebSaver.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Pack the build directory for release
         run: zip WebSaver.zip /Users/runner/Library/Developer/Xcode/DerivedData//WebSaver-dnfwrjsdcytbqjcmuceoafwrnokj/Build/Products/Debug/
       - name: Cut a new release
-        uses: ncipollo/release-action@v1
+        uses: softprops/action-gh-release@v1
         with:
-          artifacts: WebSaver.zip
+          files: WebSaver.zip


### PR DESCRIPTION
Hi, this is related to #26. I converted those instructions into a GitHub Actions workflow. The workflow is free to run (since this repository is public) and it builds the screen saver and uploads it as the artifacts of the workflow as well as creates a release in the repository tagged by the current date and time. You can see that in my fork:

https://github.com/TomasHubelbauer/websaver/releases

I am hoping you will consider merging this upstream. In combination with #26 it should make the experience of getting WebSaver much more user-friendly.